### PR TITLE
Enable CORS header for Latitude test environment

### DIFF
--- a/src/main/java/net/whydah/service/proxy/ProxyResource.java
+++ b/src/main/java/net/whydah/service/proxy/ProxyResource.java
@@ -54,7 +54,7 @@ public class ProxyResource {
     }
 
 
-    //    @CrossOrigin(value = "https://latitude.sixtysix.no", allowCredentials = "true",  allowedHeaders = "*")
+    @CrossOrigin(value = "https://latitude.sixtysix.no", allowCredentials = "true",  allowedHeaders = "*")
     @GET
     @Path("/{appname}/ping")
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
I'm currently experiencing issues with the `/ping` endpoint, thus, we need to temporary accept it in the CORS header.

We should search for a more permanent solution where the allowed origin is dependent on which service that is being loaded.
