### PR TITLE
INN-334 Forwarding query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,5 @@ The location may be overridden by setting `proxy.specification.directory`
 
 
 ### Forwarding query params
-The SPA Proxy will forward all query params by default. It will not forwards those that are specified in the setting `proxy.queryparams.disallowed`.
+The SPA Proxy will forwards query params that are whitelisted in UAWA for the application used.
+.e. set a tag called `ALLOWEDQUERYPARAMS` with a value that's the allowed query params, seperated by `;`.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Whydah-SPAProxyService
 
-
-
 ![Build Status](https://jenkins.capraconsulting.no/buildStatus/icon?job=Whydah-SPAProxyService) [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)  [![Known Vulnerabilities](https://snyk.io/test/github/Cantara/Whydah-SPAProxyService/badge.svg)](https://snyk.io/test/github/Cantara/Whydah-SPAProxyService)
 
 
-The SPAProxyService is an optinal Whydah module to support Whydah application sessions for single-page applications.
-This module is the backend/API support module for the Whydah SPA javascript npm library.
+The SPAProxyService is an optional Whydah module to support Whydah application sessions for Single-Page Applications (SPAs).
+This module is the backend/API support module for the Whydah SPA JavaScript NPM Library.
 
 
 * use:  https://spaproxy.cantara.no/proxy/health
@@ -71,12 +69,12 @@ JWT Body : {"sub":"useradmin","jti":"8bdf8ad8-b7af-4561-93be-58d420c3ea54","iss"
 
 ### Generic HTTP Proxy support
 There might be cases where you wish to expose endpoints belonging to other applications through SPAProxy.
-The endpoints:
+
+The following endpoints are used to proxy requests based on a `ProxySpecification`:
  * `../generic/{secret}/{userTokenId/{proxySpecificationName}`
  * `../generic/{secret}/{proxySpecificationName}`
 
-Are used to proxy requests based on a `ProxySpecification`. The first endpoint expects a usedTokenId in the path,
-while the second expects a valid JWT Bearer token in the Authorization header.
+The first endpoint expects a usedTokenId in the path, while the second expects a valid JWT Bearer token in the Authorization header.
 
 Currently only `GET` requests are supported, while `POST` support is planned.
 
@@ -113,3 +111,7 @@ SPAProxy will execute the GET in a Hystrix command. `command_timeout_millisecond
 
 By default SPAProxy will look for ProxySpecification files in the `proxy-specifications/` directory.
 The location may be overridden by setting `proxy.specification.directory`
+
+
+### Forwarding query params
+The SPA Proxy will forward all query params by default. It will not forwards those that are specified in the setting `proxy.queryparams.disallowed`.

--- a/src/main/java/net/whydah/service/auth/ssologin/SSOLoginResource.java
+++ b/src/main/java/net/whydah/service/auth/ssologin/SSOLoginResource.java
@@ -106,7 +106,7 @@ public class SSOLoginResource {
                                                                 @PathParam("appName") String appName) {
         Application application = credentialStore.findApplication(appName);
         if (application == null) {
-            log.info("Application not found for appliCationName {}. Returning not found", appName);
+            log.info("Application not found for applicationName {}. Returning not found", appName);
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
@@ -240,7 +240,7 @@ public class SSOLoginResource {
                     .queryParam("code", spaSessionSecret.getSecret());
 
         }
-
+        log.info("Removing the following disallowed query params from request: " + Arrays.toString(QUERY_PARAMS_NOT_FORWARDED));
         Map<String, String[]> originalQueryParamsMap = removeKeysFromMap(QUERY_PARAMS_NOT_FORWARDED, httpServletRequest.getParameterMap());
         String location = SSOLoginUtil.addQueryParamsToUri(originalQueryParamsMap, uri).build().toString();
 

--- a/src/main/java/net/whydah/service/auth/ssologin/SSOLoginUtil.java
+++ b/src/main/java/net/whydah/service/auth/ssologin/SSOLoginUtil.java
@@ -149,7 +149,7 @@ class SSOLoginUtil {
 
     static Map<String, String[]> removeKeysFromMap(String[] paramsToRemove, Map<String, String[]> map) {
         Map<String, String[]> cleanMap = new HashMap<String, String[]>();
-        for (Map.Entry<String, String[]> entry: cleanMap.entrySet()) {
+        for (Map.Entry<String, String[]> entry: map.entrySet()) {
             if (Arrays.asList(paramsToRemove).indexOf(entry.getKey()) < 0) {
                 cleanMap.put(entry.getKey(), entry.getValue());
             }

--- a/src/main/java/net/whydah/service/auth/ssologin/SSOLoginUtil.java
+++ b/src/main/java/net/whydah/service/auth/ssologin/SSOLoginUtil.java
@@ -2,9 +2,11 @@ package net.whydah.service.auth.ssologin;
 
 import net.whydah.service.CredentialStore;
 import net.whydah.service.spasession.ResponseUtil;
+import net.whydah.sso.application.mappers.ApplicationTagMapper;
 import net.whydah.sso.application.mappers.ApplicationTokenMapper;
 import net.whydah.sso.application.types.Application;
 import net.whydah.sso.application.types.ApplicationToken;
+import net.whydah.sso.application.types.Tag;
 import net.whydah.sso.commands.userauth.CommandGetUsertokenByUserticket;
 import net.whydah.sso.user.mappers.UserTokenMapper;
 import net.whydah.sso.user.types.UserToken;
@@ -147,16 +149,31 @@ class SSOLoginUtil {
         return uriBuilder;
     }
 
-    static Map<String, String[]> removeKeysFromMap(String[] paramsToRemove, Map<String, String[]> map) {
-        Map<String, String[]> cleanMap = new HashMap<String, String[]>();
-        for (Map.Entry<String, String[]> entry: map.entrySet()) {
-            if (Arrays.asList(paramsToRemove).indexOf(entry.getKey()) < 0) {
-                cleanMap.put(entry.getKey(), entry.getValue());
+
+    /**
+     * removeKeysFromMap
+     * @param paramsToKeep
+     * @param map
+     * @return cleanMap, i.e. a map with only paramsToKeep
+     */
+    static Map<String, String[]> removeKeysFromMap(String[] paramsToKeep, Map<String, String[]> map) {
+       Map<String, String[]> cleanQueryParamMap = new HashMap<String, String[]>();
+       List paramsToKeepAsArray = Arrays.asList(paramsToKeep);
+       for (Map.Entry<String, String[]> entry: map.entrySet()) {
+            if (paramsToKeepAsArray.indexOf(entry.getKey()) >= 0) {
+                cleanQueryParamMap.put(entry.getKey(), entry.getValue());
             }
         }
-        return cleanMap;
+       return cleanQueryParamMap;
     }
 
+    /**
+     * buildQueryParamsForRedirectUrl
+     * @param ssoLoginUUID
+     * @param application
+     * @param originalParameterMap
+     * @return Map of query params to be used in a redirect URL
+     */
     static Map<String, String[]> buildQueryParamsForRedirectUrl(UUID ssoLoginUUID, final Application application,
                                                                 final Map<String, String[]> originalParameterMap) {
 
@@ -169,6 +186,23 @@ class SSOLoginUtil {
         forwardedParameterMap.put("targetApplicationId", new String[]{application.getId()});
         forwardedParameterMap.put("ssoLoginUUID", new String[]{ssoLoginUUID.toString()});
         return forwardedParameterMap;
+    }
+
+    /**
+     * getAllowedQueryParamsForApplication
+     * @param application
+     * @return String array of allowed query params
+     */
+    static String[] getAllowedQueryParamsForApplication(Application application) {
+        final String WHITELISTED_QUERY_PARAMS_TAG_NAME = "ALLOWEDQUERYPARAMS";
+
+        List<Tag> tagList = ApplicationTagMapper.getTagList(application.getTags());
+        for (Tag tag : tagList) {
+            if (tag.getName().equalsIgnoreCase(WHITELISTED_QUERY_PARAMS_TAG_NAME)) {
+                return tag.getValue().split(";");
+            }
+        }
+        return new String[0];
     }
 
     static URI buildPopupEntryPointURIWithApplicationSession(String spaProxyBaseURI, String sessionSecret, UUID ssoLoginUUID) {

--- a/src/main/java/net/whydah/service/auth/ssologin/SSOLoginUtil.java
+++ b/src/main/java/net/whydah/service/auth/ssologin/SSOLoginUtil.java
@@ -17,10 +17,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 /**
  *
@@ -134,6 +131,30 @@ class SSOLoginUtil {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * addQueryParamsToUri
+     * @description Takes an UriBuilder and params, and adds the param set to the URI
+     * @param params
+     * @param uriBuilder
+     * @return uriBuilder with the params
+     */
+    static UriBuilder addQueryParamsToUri(Map<String, String[]> params, UriBuilder uriBuilder) {
+        for (Map.Entry<String, String[]> entry : params.entrySet()) {
+            uriBuilder.queryParam(entry.getKey(), entry.getValue()[0]);
+        }
+        return uriBuilder;
+    }
+
+    static Map<String, String[]> removeKeysFromMap(String[] paramsToRemove, Map<String, String[]> map) {
+        Map<String, String[]> cleanMap = new HashMap<String, String[]>();
+        for (Map.Entry<String, String[]> entry: cleanMap.entrySet()) {
+            if (Arrays.asList(paramsToRemove).indexOf(entry.getKey()) < 0) {
+                cleanMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return cleanMap;
     }
 
     static Map<String, String[]> buildQueryParamsForRedirectUrl(UUID ssoLoginUUID, final Application application,

--- a/src/main/java/net/whydah/service/httpproxy/ProxySpecification.java
+++ b/src/main/java/net/whydah/service/httpproxy/ProxySpecification.java
@@ -36,7 +36,6 @@ public class ProxySpecification implements Serializable, Cloneable {
 
     private static final Logger log = LoggerFactory.getLogger(ProxySpecification.class);
 
-
     public ProxySpecification(@JsonProperty("command_url") String command_url,
                               @JsonProperty("command_contenttype") String command_contenttype,
                               @JsonProperty("command_http_authstring") String command_http_authstring,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,4 +24,4 @@ jetty.request.log.enabled=true
 
 proxy.specification.load.from.classpath=false
 proxy.specification.directory=proxy-specifications
-proxy.queryparams.disallowed=usertoken
+proxy.queryparams.disallowed=userticket

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,4 @@ jetty.request.log.enabled=true
 
 proxy.specification.load.from.classpath=false
 proxy.specification.directory=proxy-specifications
+proxy.queryparams.disallowed=usertoken

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,4 +24,3 @@ jetty.request.log.enabled=true
 
 proxy.specification.load.from.classpath=false
 proxy.specification.directory=proxy-specifications
-proxy.queryparams.disallowed=userticket

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginRepositoryTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginRepositoryTest.java
@@ -80,7 +80,7 @@ public class SSOLoginRepositoryTest {
         ZonedDateTime initialized = retrievedSession.getInitializedTimestamp();
         assertNotNull(initialized);
 
-        //Thread should have automatically deleted the old session after maxAgeSeconds
+        //Thread should have the old session deleted automatically after maxAgeSeconds
 
         TimeUnit.SECONDS.sleep(3);
         SSOLoginSession afterCleanUp = ssoLoginRepository.get(uuid);

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginRepositoryTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginRepositoryTest.java
@@ -80,7 +80,7 @@ public class SSOLoginRepositoryTest {
         ZonedDateTime initialized = retrievedSession.getInitializedTimestamp();
         assertNotNull(initialized);
 
-        //Thread should have automaticall deleted the old session after maxAgeSeconds
+        //Thread should have automatically deleted the old session after maxAgeSeconds
 
         TimeUnit.SECONDS.sleep(3);
         SSOLoginSession afterCleanUp = ssoLoginRepository.get(uuid);

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginResourceWithSessionTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginResourceWithSessionTest.java
@@ -278,4 +278,61 @@ public class SSOLoginResourceWithSessionTest extends AbstractEndpointTest {
         assertFalse(jwt.isEmpty());
     }
 
+    @Test
+    public void verifyQueryParamRedirect() {
+        final String testAppName = "testApp";
+
+        // Extract secret from a load for the application
+        ValidatableResponse validatableResponse = given()
+                .when()
+                .port(getServerPort())
+                .redirects().follow(false) //Do not follow the redirect
+                .get("/load/" + testAppName)
+                .then().log().ifError()
+                .statusCode(Response.Status.FOUND.getStatusCode());
+
+        String locationHeader = validatableResponse.extract().header("Location");
+        MultiValueMap<String, String> queryParams = UriComponentsBuilder.fromUriString(locationHeader).build().getQueryParams();
+        String secret = queryParams.get("code").get(0);
+        assertNotNull(secret);
+        assertFalse(secret.isEmpty());
+
+
+        // Initialize the user login
+        String apiPath = "/application/session/" + secret + "/user/auth/ssologin/";
+        ValidatableResponse initResponse = given()
+                .when()
+                .port(getServerPort())
+                .post(apiPath)
+                .then().log().ifValidationFails()
+                .statusCode(Response.Status.OK.getStatusCode());
+        String ssoLoginUrl = initResponse.extract().path("ssoLoginUrl");
+        String ssoLoginUUID = initResponse.extract().path("ssoLoginUUID");
+
+        ValidatableResponse redirectResponse = given()
+                .when()
+                .redirects().follow(false) //Do not follow the redirect
+                .get(ssoLoginUrl)
+                .then().log().ifValidationFails()
+                .statusCode(Response.Status.FOUND.getStatusCode());
+
+        String location = redirectResponse.extract().header("Location");
+
+        assertNotNull(location);
+        assertFalse(location.isEmpty());
+
+        String expectedRedirectURI = Configuration.getString("myuri") +
+                "/application/testApp/user/auth/ssologin/" + ssoLoginUUID + "/complete";
+
+        String expectedLocation = UriBuilder.fromUri(Configuration.getString("logonservice"))
+                .path("login")
+                .queryParam("redirectURI", expectedRedirectURI)
+                .queryParam("ssoLoginUUID", ssoLoginUUID)
+                .queryParam("targetApplicationId", "inMemoryTestAppId")
+                .build()
+                .toString();
+
+        assertEquals(location, expectedLocation);
+    }
+
 }

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginResourceWithoutSessionTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginResourceWithoutSessionTest.java
@@ -230,7 +230,7 @@ public class SSOLoginResourceWithoutSessionTest extends AbstractEndpointTest {
         final String testAppName = "testApp";
         final String testQueryParamKey = "someExtraQueryParam";
         final String testQueryParamValue = "someQueryParamValue";
-        final String[] disallowedQueryParams = Configuration.getString("proxy.queryparams.disallowed").split(",");
+        final String[] disallowedQueryParams = {"userticket"};
 
         // Initialize the user login
         String apiPath = "/application/" + testAppName + "/user/auth/ssologin/";

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginUtilTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginUtilTest.java
@@ -1,15 +1,15 @@
 package net.whydah.service.auth.ssologin;
 
 import net.whydah.sso.application.types.Application;
+import org.apache.http.client.utils.URIBuilder;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
+import java.net.URL;
 import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static org.testng.Assert.*;
 
@@ -190,5 +190,23 @@ public class SSOLoginUtilTest {
         assertNotNull(hash1);
         assertFalse(hash1.isEmpty());
         assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void test_addQueryParamsToUri() {
+        Map<String, String[]> queryParams = new HashMap<String, String[]>();
+        String key1 = "someParam";
+        String key2 = "someParam2";
+        String[] value1 = {"someValue"};
+        String[] value2 = {"someOtherValue"};
+        queryParams.put(key1, value1);
+        queryParams.put(key2, value2);
+
+        String mockUri = "http://www.someodmain.com/somewhere";
+        UriBuilder mockUriBuilder = UriBuilder.fromUri(mockUri);
+        UriBuilder uriBuilderWithParams = SSOLoginUtil.addQueryParamsToUri(queryParams, mockUriBuilder);
+        assertNotNull(uriBuilderWithParams);
+        assertEquals(uriBuilderWithParams.build().toString(), String.format(mockUri + "?%s=%s&%s=%s", key2, value2[0], key1, value1[0]));
+
     }
 }

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginUtilTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginUtilTest.java
@@ -193,6 +193,24 @@ public class SSOLoginUtilTest {
     }
 
     @Test
+    public void test_removeKeysFromMap() {
+        Map<String, String[]> originalQueryParamMap = new HashMap<String, String[]>();
+
+        String key1 = "someParam";
+        String key2 = "someParam2";
+        String[] value1 = {"someValue"};
+        String[] value2 = {"someOtherValue"};
+        originalQueryParamMap.put(key1, value1);
+        originalQueryParamMap.put(key2, value2);
+        Map<String, String[]> expectedCleanMap = new HashMap<String, String[]>(originalQueryParamMap);
+        expectedCleanMap.remove(key1);
+
+        String[] paramsToRemove = {key1};
+        Map<String, String[]> cleanMap = SSOLoginUtil.removeKeysFromMap(paramsToRemove, originalQueryParamMap);
+        assertEquals(cleanMap, expectedCleanMap);
+    }
+
+    @Test
     public void test_addQueryParamsToUri() {
         Map<String, String[]> queryParams = new HashMap<String, String[]>();
         String key1 = "someParam";

--- a/src/test/java/net/whydah/service/auth/ssologin/SSOLoginUtilTest.java
+++ b/src/test/java/net/whydah/service/auth/ssologin/SSOLoginUtilTest.java
@@ -202,11 +202,14 @@ public class SSOLoginUtilTest {
         String[] value2 = {"someOtherValue"};
         originalQueryParamMap.put(key1, value1);
         originalQueryParamMap.put(key2, value2);
-        Map<String, String[]> expectedCleanMap = new HashMap<String, String[]>(originalQueryParamMap);
-        expectedCleanMap.remove(key1);
 
-        String[] paramsToRemove = {key1};
-        Map<String, String[]> cleanMap = SSOLoginUtil.removeKeysFromMap(paramsToRemove, originalQueryParamMap);
+        Map<String, String[]> expectedCleanMap = new HashMap<String, String[]>(originalQueryParamMap);
+
+        String[] paramsToKeep = {key1};
+        expectedCleanMap.remove(key2);
+
+        Map<String, String[]> cleanMap = SSOLoginUtil.removeKeysFromMap(paramsToKeep, originalQueryParamMap);
+
         assertEquals(cleanMap, expectedCleanMap);
     }
 

--- a/src/test/java/net/whydah/testsupport/AbstractEndpointTest.java
+++ b/src/test/java/net/whydah/testsupport/AbstractEndpointTest.java
@@ -132,6 +132,7 @@ public abstract class AbstractEndpointTest {
         // get applications from UAS. Return single testApp
         Application application = new Application("inMemoryTestAppId", "testApp");
         application.setApplicationUrl("http://dummy.url.does.not.exist.com");
+        application.setTags("ALLOWEDQUERYPARAMS_code;firstName;lastName;streetAddress;someExtraQueryParam;");
         addStub(WireMock.get(urlEqualTo("/useradminservice/86560f039fcfbb083bed8c12da58bdee/applications"))
                 .willReturn(WireMock.aResponse()
                         .withStatus(200)


### PR DESCRIPTION
This PR implements support for forwarding query params, i.e. forwarding query params that are not sensitive. This is first and foremost used in INN-JS (and other libraries) so it can get CrmData for unregistered user from, passed by SSOLWA through query params.
This might also be useful for other applications using Whydah.